### PR TITLE
Set signed parameter for conversion from hex to int

### DIFF
--- a/inverter/utilities/modbus_converter.py
+++ b/inverter/utilities/modbus_converter.py
@@ -19,7 +19,7 @@ def hex2int(*, data_hex: str, scale, offset) -> int:
     """
     logger.debug(f'{data_hex=} {scale=} {offset=}')
     data = bytes.fromhex(data_hex)
-    number = int.from_bytes(data, byteorder='big')
+    number = int.from_bytes(data, byteorder='big',signed=True)
 
     if offset:
         logger.debug(f'{number=} {offset=}')


### PR DESCRIPTION
Some numbers are twos complement.
They need the signed parameter to get converted correctly. This is important when the script is used for the bigger inverters of deye, e.g. deye sun-8k-sg04lp3